### PR TITLE
Translation checkout form fields.

### DIFF
--- a/class-edd-multilingual.php
+++ b/class-edd-multilingual.php
@@ -20,6 +20,10 @@ class EDD_Multilingual {
 			add_action( 'admin_notices', array( $this, 'error_no_plugins' ) );
 
 			return;
+		} elseif ( version_compare( ICL_SITEPRESS_VERSION, '4.0', '<' ) ) {
+			add_action( 'admin_notices', array( $this, 'error_wpml_update' ) );
+
+			return;
 		}
 
 		// WPML setup has to be finished.
@@ -44,6 +48,14 @@ class EDD_Multilingual {
 				                '<a href="http://wpml.org/">WPML</a>',
 				                '<a href="https://wordpress.org/plugins/easy-digital-downloads/">Easy Digital Downloads</a>' ) .
 			 '</p></div>';
+	}
+
+	/**
+	 * Error message if WPML is not recent enough.
+	 */
+	public function error_wpml_update() {
+		$message = __( '%s plugin is enabled but not effective. It requires at least WPML 4.0.', 'edd_multilingual' );
+		echo '<div class="error"><p>' . sprintf( $message, '<strong>EDD multilingual</strong>' ) . '</p></div>';
 	}
 
 	/**

--- a/class-edd-multilingual.php
+++ b/class-edd-multilingual.php
@@ -82,6 +82,9 @@ class EDD_Multilingual {
 		) {
 			add_action( 'init', array( $this, 'remove_wpml_language_filter' ) );
 		}
+
+		// Support for 'Checkout Fields Manager' extension.
+		add_filter( 'option_cfm-checkout-form', array( $this, 'translate_checkout_fields_id' ) );
 	}
 
 	/**
@@ -139,6 +142,13 @@ class EDD_Multilingual {
 		isset( $edd_options['fes-login-form'] ) ? $edd_options['fes-login-form'] = apply_filters( 'wpml_object_id', $edd_options['fes-login-form'], 'page', true ) : '';
 		isset( $edd_options['fes-registration-form'] ) ? $edd_options['fes-registration-form']  = apply_filters( 'wpml_object_id', $edd_options['fes-registration-form'], 'page', true ) : '';
 		isset( $edd_options['fes-vendor-contact-form'] ) ? $edd_options['fes-vendor-contact-form'] = apply_filters( 'wpml_object_id', $edd_options['fes-vendor-contact-form'], 'page', true ) : '';
+	}
+
+	/**
+	 * Translate the post_id for checkout fields.
+	 */
+	function translate_checkout_fields_id( $id ) {
+		return apply_filters( 'wpml_object_id', $id, 'edd-checkout-fields', true );
 	}
 
 	/**

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -14,6 +14,9 @@
         <custom-field action="copy">_edd_purchase_color</custom-field>
         <custom-field action="translate">_edd_purchase_text</custom-field>
         <custom-field action="translate">edd_product_notes</custom-field>
+        <custom-field action="translate">cfm-form</custom-field>
+        <custom-field action="copy">cfm-form-class</custom-field>
+        <custom-field action="copy">cfm-form-name</custom-field>
     </custom-fields>
     <taxonomies>
         <taxonomy translate="1">download_category</taxonomy>


### PR DESCRIPTION
The labels for checkout form fields aren't being translated.

The change in this branch together with next release of WPML (3.9) will fix this.

First reported in https://wpml.org/forums/topic/easy-digital-downloads-only-partially-translated/