### PR TITLE
[compdev-1028] Bump tested WP version to `7.0` and bump plugin version to `1.4.4`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # WPML Multilingual for Easy Digital Downloads
 
-![Latest Stable Version](https://img.shields.io/badge/stable-1.4.3-green.svg?style=flat-squar)
+![Latest Stable Version](https://img.shields.io/badge/stable-1.4.4-green.svg?style=flat-squar)
 ![License](https://img.shields.io/badge/license-GPLv2-red.svg?style=flat-squar)
 
 

--- a/edd-multilingual.php
+++ b/edd-multilingual.php
@@ -3,7 +3,7 @@
 Plugin Name: WPML Multilingual for Easy Digital Downloads
 Plugin URI: https://wordpress.org/plugins/edd-multilingual/
 Description: A plugin that enables seamless integration between Easy Digital Downloads and WPML | <a href="https://wpml.org/documentation/related-projects/easy-digital-downloads-multilingual/?utm_source=plugin&utm_medium=gui&utm_campaign=eddml">Documentation</a>
-Version: 1.4.3
+Version: 1.4.4
 Author: OnTheGoSystems
 Author URI: http://www.onthegosystems.com/
 Text Domain: edd_multilingual
@@ -13,7 +13,7 @@ if ( defined( 'EDD_MULTILINGUAL_VERSION' ) ) {
 	return;
 }
 
-define( 'EDD_MULTILINGUAL_VERSION', '1.4.3' );
+define( 'EDD_MULTILINGUAL_VERSION', '1.4.4' );
 define( 'EDD_MULTILINGUAL_PATH', __DIR__ );
 
 require EDD_MULTILINGUAL_PATH . '/class-edd-multilingual.php';

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: http://wpml.org/documentation/related-projects/easy-digital-downloa
 Tags: e-commerce, multilingual, WPML, download, EDD
 License: GPLv2
 Requires at least: 4.7
-Tested up to: 6.9
-Stable tag: 1.4.3
+Tested up to: 7.0
+Stable tag: 1.4.4
 
 WPML Multilingual for Easy Digital Downloads is the glue plugin that provides seamless integration between Easy Digital Downloads and WPML.
 
@@ -33,6 +33,9 @@ This is a glue plugin between EDD and WPML. You need to have both in order for t
 2. Payments history table with language information
 
 == Changelog ==
+
+= 1.4.4 =
+* Bump WordPress tested version.
 
 = 1.4.3 =
 * Rename plugin.


### PR DESCRIPTION
https://onthegosystems.myjetbrains.com/youtrack/issue/compdev-1028